### PR TITLE
Fix mode base rerefence

### DIFF
--- a/Scripts/Modes/Trackmania/EscapeMania.Script.txt
+++ b/Scripts/Modes/Trackmania/EscapeMania.Script.txt
@@ -1,6 +1,6 @@
 // #RequireContext CSmMode
 
-#Extends "Libs/Nadeo/TMNext/TrackMania/Modes/TMNextBase.Script.txt"
+#Extends "Modes/Nadeo/Trackmania/Base/TrackmaniaBase.Script.txt"
 
 #Include "Libs/EscapeMania/ModeLibs/EscapeMania/Rooms/Rooms.Script.txt" as Rooms
 #Include "Libs/EscapeMania/ModeLibs/EscapeMania/Rooms/RoomsRequestRespawn.Script.txt" as RoomsRequestRespawn
@@ -148,7 +148,7 @@ foreach (Event in PendingEvents) {
 		case CSmModeEvent::EType::OnPlayerRequestRespawn: {
 			OnRespawn(Event.Player, Null);
 		}
-		case CSmModeEvent::EType::OnPlayerAdded: {	
+		case CSmModeEvent::EType::OnPlayerAdded: {
 			UIManager.UIAll.SendChat(Event.Player.User.Name ^ " joined the Escape!");
 		}
 		case CSmModeEvent::EType::OnPlayerRemoved: {


### PR DESCRIPTION
The latest fall update moved almost every script to a new location. Fortunately, the only Nando script we seem to depend on is the modebase.

If I recall correctly, the `TMNextBase` base mode was the highest level mode base that other gamemodes usually use. A lot of files got renamed and the it now seems to be `TrackmaniaBase`. With the new modebase, the gamemode seems to load and basic functionality (Hints, timer, respawn, ...) seems to work, but I didn't test everythign as I don't know how.

It should be properly tested again.